### PR TITLE
Improve index.js special case handling

### DIFF
--- a/Require.py
+++ b/Require.py
@@ -3,6 +3,7 @@ import sublime_plugin
 import os
 import json
 import re
+from os import path
 
 has_rel_path = re.compile("\.?\.?\/")
 
@@ -43,7 +44,7 @@ class RequireCommand(sublime_plugin.TextCommand):
 
     def load_file_list(self):
         self.parse_package_json()
-        dirname = os.path.dirname(self.view.file_name())
+        dirname = path.dirname(self.view.file_name())
         walk = os.walk(self.project_folder)
         for root, dirs, files in walk:
             if 'node_modules' in dirs:
@@ -53,9 +54,9 @@ class RequireCommand(sublime_plugin.TextCommand):
             for file_name in files:
                 if file_name[0] is not '.':
                     file_name = "%s/%s" % (root, file_name)
-                    file_name = os.path.relpath(file_name, dirname)
+                    file_name = path.relpath(file_name, dirname)
 
-                    if file_name == os.path.basename(self.view.file_name()):
+                    if file_name == path.basename(self.view.file_name()):
                         continue
 
                     if not has_rel_path.match(file_name):
@@ -64,7 +65,7 @@ class RequireCommand(sublime_plugin.TextCommand):
                 self.files.append(file_name)
 
     def parse_package_json(self):
-        package = os.path.join(self.project_folder, 'package.json')
+        package = path.join(self.project_folder, 'package.json')
         package_json = json.load(open(package, 'r'))
         dependencyTypes = (
             'dependencies',
@@ -95,14 +96,14 @@ class RequireInsertHelperCommand(sublime_plugin.TextCommand):
         if module in aliases:
             module_name = aliases[module]
         else:
-            module_name = os.path.basename(module)
-            module_name, extension = os.path.splitext(module_name)
+            module_name = path.basename(module)
+            module_name, extension = path.splitext(module_name)
             if module.endswith('/index.js'):
-                module_name = os.path.split(os.path.dirname(module))[-1]
+                module_name = path.split(path.dirname(module))[-1]
                 module = module[:-9]
                 if module_name == '' or '.' in module_name:
-                    directory = os.path.dirname(self.view.file_name())
-                    module_name = os.path.split(directory)[-1]
+                    directory = path.dirname(self.view.file_name())
+                    module_name = path.split(directory)[-1]
 
             if module.endswith(".js"):
                 module = module[:-3]


### PR DESCRIPTION
``` js
// Previously
var codecs = require("./codecs/index");

// Now
var codecs = require("./codecs/");
```

Also handles paths in root directory 
