### PR TITLE
Semicolon handling plus jscs support

### DIFF
--- a/.build
+++ b/.build
@@ -1,0 +1,11 @@
+{
+	"automatic_order": true,
+	"iterations": 1,
+	"mods_load_order":
+	[
+		"src/utils.py",
+		"src/modules.py",
+		"src/RequireSnippet.py",
+		"NodeRequirer.py"
+	]
+}

--- a/NodeRequirer.py
+++ b/NodeRequirer.py
@@ -362,12 +362,12 @@ class RequireInsertHelperCommand(sublime_plugin.TextCommand):
         )
         should_add_var = (not prev_text.endswith((':', '=')) and
                           not in_brackets)
-        should_add_semicolon = (not next_text.startswith((';', ',')) and
+        context_allows_semicolon = (not next_text.startswith((';', ',')) and
                                 not in_brackets)
 
         snippet = RequireSnippet(module_name, module_path, quotes,
                                  should_add_var, should_add_var_statement,
-                                 should_add_semicolon,
+                                 context_allows_semicolon,
                                  file_name=view.file_name())
         view.run_command('insert_snippet', snippet.get_args())
 

--- a/NodeRequirer.py
+++ b/NodeRequirer.py
@@ -352,6 +352,7 @@ class RequireInsertHelperCommand(sublime_plugin.TextCommand):
 
         cursor = view.sel()[0]
         prev_text = view.substr(sublime.Region(0, cursor.begin())).strip()
+        next_text = view.substr(sublime.Region(cursor.end(), cursor.end() + 80)).strip()
         last_bracket = self.get_last_opened_bracket(prev_text)
         in_brackets = last_bracket in ('(', '[')
         last_word = re.split(WORD_SPLIT_RE, prev_text)[-1]
@@ -361,9 +362,12 @@ class RequireInsertHelperCommand(sublime_plugin.TextCommand):
         )
         should_add_var = (not prev_text.endswith((':', '=')) and
                           not in_brackets)
+        should_add_semicolon = (not next_text.startswith((';', ',')) and
+                                not in_brackets)
 
         snippet = RequireSnippet(module_name, module_path, quotes,
-                                 should_add_var, should_add_var_statement)
+                                 should_add_var, should_add_var_statement,
+                                 should_add_semicolon)
         view.run_command('insert_snippet', snippet.get_args())
 
     def get_last_opened_bracket(self, text):

--- a/NodeRequirer.py
+++ b/NodeRequirer.py
@@ -367,7 +367,8 @@ class RequireInsertHelperCommand(sublime_plugin.TextCommand):
 
         snippet = RequireSnippet(module_name, module_path, quotes,
                                  should_add_var, should_add_var_statement,
-                                 should_add_semicolon)
+                                 should_add_semicolon,
+                                 file_name=view.file_name())
         view.run_command('insert_snippet', snippet.get_args())
 
     def get_last_opened_bracket(self, text):

--- a/NodeRequirer.py
+++ b/NodeRequirer.py
@@ -105,6 +105,11 @@ class RequireCommand(sublime_plugin.TextCommand):
         self.get_local_files()
 
     def get_local_files(self):
+        # Don't throw errors if invoked in a view without a filename like the console
+        if not self.view.file_name():
+            print('Not in a file, ignoring local files.')
+            return
+
         dirname = os.path.dirname(self.view.file_name())
         exclude = set(['node_modules', '.git',
                        'bower_components', 'components'])

--- a/NodeRequirer.py
+++ b/NodeRequirer.py
@@ -195,9 +195,9 @@ class RequireCommand(sublime_plugin.TextCommand):
         )
 
     def parse_dependency_module_exports(self):
-        base_path = './node_modules/' + self.module
+        base_path = os.path.join(self.project_folder, 'node_modules', self.module)
         package = json.load(
-            open(base_path + '/package.json', 'r', encoding='UTF-8'))
+            open(os.path.join(base_path, 'package.json'), 'r', encoding='UTF-8'))
         main = 'index.js' if 'main' not in package else package['main']
         main_path = os.path.join(base_path, main)
         return self.parse_exports_in_file(main_path)

--- a/NodeRequirer.py
+++ b/NodeRequirer.py
@@ -364,8 +364,9 @@ class RequireInsertHelperCommand(sublime_plugin.TextCommand):
                                 not in_brackets)
 
         snippet = RequireSnippet(module_name, module_path,
-                                 should_add_var, should_add_var_statement,
-                                 context_allows_semicolon,
+                                 should_add_var=should_add_var,
+                                 should_add_var_statement=should_add_var_statement,
+                                 context_allows_semicolon=context_allows_semicolon,
                                  file_name=view.file_name())
         view.run_command('insert_snippet', snippet.get_args())
 

--- a/NodeRequirer.py
+++ b/NodeRequirer.py
@@ -346,8 +346,6 @@ class RequireInsertHelperCommand(sublime_plugin.TextCommand):
         module_path = module_info['module_path']
         module_name = module_info['module_name']
 
-        quotes = utils.get_quotes()
-
         view = self.view
 
         cursor = view.sel()[0]
@@ -365,7 +363,7 @@ class RequireInsertHelperCommand(sublime_plugin.TextCommand):
         context_allows_semicolon = (not next_text.startswith((';', ',')) and
                                 not in_brackets)
 
-        snippet = RequireSnippet(module_name, module_path, quotes,
+        snippet = RequireSnippet(module_name, module_path,
                                  should_add_var, should_add_var_statement,
                                  context_allows_semicolon,
                                  file_name=view.file_name())

--- a/NodeRequirer.sublime-settings
+++ b/NodeRequirer.sublime-settings
@@ -43,6 +43,9 @@
     // Use 'single' or "double" quotes
     "quotes": "single",
 
+    // Don't insert semicolons at the end of lines
+    "semicolon_free": false,
+
     // Use 'var', 'const', or 'let' variable declarations
     "var": "var",
 

--- a/src/RequireSnippet.py
+++ b/src/RequireSnippet.py
@@ -1,14 +1,13 @@
-from .utils import get_pref, get_jscs_options
+from .utils import get_pref, get_quotes, get_jscs_options
 
 class RequireSnippet():
 
-    def __init__(self, name, path, quotes,
+    def __init__(self, name, path,
                  should_add_var, should_add_var_statement,
                  context_allows_semicolon,
                  file_name=None):
         self.name = name
         self.path = path
-        self.quotes = quotes
         self.should_add_var = should_add_var
         self.should_add_var_statement = should_add_var_statement
         self.context_allows_semicolon = context_allows_semicolon
@@ -45,13 +44,25 @@ class RequireSnippet():
         return fmt.format(
             name=self.name,
             path=self.path,
-            quote=self.quotes
+            quote=self.get_quotes()
         )
 
     def get_args(self):
         return {
             'contents': self.get_formatted_code()
         }
+
+    def get_quotes(self):
+        # Allow explicit validateQuoteMarks rules to override the quote preferences
+        # However ignore the 'true' autodetection setting.
+        jscs_quotes = self.jscs_options.get('validateQuoteMarks')
+        if isinstance(jscs_quotes, dict):
+            jscs_quotes = jscs_quotes.get('mark')
+        if jscs_quotes and jscs_quotes != True:
+            return jscs_quotes
+
+        # Use whatever quote type is set in preferences
+        return get_quotes()
 
     def should_add_semicolon(self):
         # Ignore semicolons when jscs options say to

--- a/src/RequireSnippet.py
+++ b/src/RequireSnippet.py
@@ -4,14 +4,14 @@ class RequireSnippet():
 
     def __init__(self, name, path, quotes,
                  should_add_var, should_add_var_statement,
-                 should_add_semicolon,
+                 context_allows_semicolon,
                  file_name=None):
         self.name = name
         self.path = path
         self.quotes = quotes
         self.should_add_var = should_add_var
         self.should_add_var_statement = should_add_var_statement
-        self.should_add_semicolon = should_add_semicolon
+        self.context_allows_semicolon = context_allows_semicolon
         self.es6import = get_pref('import')
         self.var_type = get_pref('var')
         if self.var_type not in ('var', 'const', 'let'):
@@ -21,12 +21,9 @@ class RequireSnippet():
         if self.file_name:
             self.jscs_options = get_jscs_options(self.file_name)
 
-        # Allow jscs options to override settings
-        if self.jscs_options.get('disallowSemicolons', False):
-            self.should_add_semicolon = False
-
     def get_formatted_code(self):
         should_use_snippet = self.should_use_snippet()
+        should_add_semicolon = self.should_add_semicolon()
         require_fmt = 'require({quote}{path}{quote});'
         import_fmt = 'import {name} from {quote}{path}{quote}'
 
@@ -40,7 +37,7 @@ class RequireSnippet():
             if self.should_add_var_statement:
                 require_fmt = self.var_type + ' ' + require_fmt
 
-        if not self.should_add_semicolon:
+        if not should_add_semicolon:
             require_fmt = require_fmt.rstrip(';')
 
         fmt = import_fmt if self.es6import else require_fmt
@@ -55,6 +52,16 @@ class RequireSnippet():
         return {
             'contents': self.get_formatted_code()
         }
+
+    def should_add_semicolon(self):
+        # Ignore semicolons when jscs options say to
+        if self.jscs_options.get('disallowSemicolons', False):
+            return False
+
+        if get_pref('semicolon_free'):
+            return False
+
+        return self.context_allows_semicolon
 
     def should_use_snippet(self):
         return get_pref('snippet')

--- a/src/RequireSnippet.py
+++ b/src/RequireSnippet.py
@@ -3,12 +3,14 @@ from .utils import get_pref
 class RequireSnippet():
 
     def __init__(self, name, path, quotes,
-                 should_add_var, should_add_var_statement):
+                 should_add_var, should_add_var_statement,
+                 should_add_semicolon):
         self.name = name
         self.path = path
         self.quotes = quotes
         self.should_add_var = should_add_var
         self.should_add_var_statement = should_add_var_statement
+        self.should_add_semicolon = should_add_semicolon
         self.es6import = get_pref('import')
         self.var_type = get_pref('var')
         if self.var_type not in ('var', 'const', 'let'):
@@ -28,6 +30,9 @@ class RequireSnippet():
             require_fmt = '{name} = ' + require_fmt
             if self.should_add_var_statement:
                 require_fmt = self.var_type + ' ' + require_fmt
+
+        if not self.should_add_semicolon:
+            require_fmt = require_fmt.rstrip(';')
 
         fmt = import_fmt if self.es6import else require_fmt
 

--- a/src/RequireSnippet.py
+++ b/src/RequireSnippet.py
@@ -1,10 +1,11 @@
-from .utils import get_pref
+from .utils import get_pref, get_jscs_options
 
 class RequireSnippet():
 
     def __init__(self, name, path, quotes,
                  should_add_var, should_add_var_statement,
-                 should_add_semicolon):
+                 should_add_semicolon,
+                 file_name=None):
         self.name = name
         self.path = path
         self.quotes = quotes
@@ -15,6 +16,14 @@ class RequireSnippet():
         self.var_type = get_pref('var')
         if self.var_type not in ('var', 'const', 'let'):
             self.var_type = 'var'
+        self.file_name = file_name
+        self.jscs_options = dict()
+        if self.file_name:
+            self.jscs_options = get_jscs_options(self.file_name)
+
+        # Allow jscs options to override settings
+        if self.jscs_options.get('disallowSemicolons', False):
+            self.should_add_semicolon = False
 
     def get_formatted_code(self):
         should_use_snippet = self.should_use_snippet()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 import sublime
+from .modules import core_modules
 
 SETTINGS_FILE = "NodeRequirer.sublime-settings"
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,9 @@
 import sublime
+import os
+import io
+import json
+import re
+
 from .modules import core_modules
 
 SETTINGS_FILE = "NodeRequirer.sublime-settings"
@@ -18,3 +23,63 @@ def is_core_module(module):
 
 def is_local_file(module):
     return '/' in module
+
+
+def lazy_parse_comment_json(json_text):
+	"""
+	This attempts to parse files like .jscsrc which are .json files with
+	comments in them.
+
+	This is lazy in that we simply strip things with a regexp and don't take string boundaries into account.
+	This should be fine since it's unlikely that any of the config options we want contain comment-like text
+	"""
+
+	if isinstance(json_text, io.IOBase):
+		json_text = json_text.read()
+
+	json_text = re.sub(r'(#|//).*$', '', json_text, re.MULTILINE)
+	json_text = re.sub(r'/\*.*\*/', '', json_text, re.DOTALL)
+	return json.loads(json_text)
+
+
+def get_jscs_options(path):
+	option_sets = []
+
+	jscsrc_path = findup(path, '.jscsrc')
+	if os.path.isfile(jscsrc_path):
+		jscsrc = lazy_parse_comment_json(open(jscsrc_path, 'r', encoding='UTF-8'))
+		option_sets.append((jscsrc_path, jscsrc))
+
+	jscs_json_path = findup(path, '.jscs.json')
+	if os.path.isfile(jscs_json_path):
+		jscs_json = json.load(open(jscs_json_path, 'r', encoding='UTF-8'))
+		option_sets.append((jscs_json_path, jscs_json))
+
+	package_path = findup(path, 'package.json')
+	if os.path.isfile(package_path):
+		package = json.load(open(package_path, 'r', encoding='UTF-8'))
+		if 'jscsConfig' in package:
+			option_sets.append((package_path, package['jscsConfig']))
+
+	# Sort sets by dirname length
+	option_sets.sort(key=lambda x: len(os.path.dirname(x[0])))
+
+	# Merge options together
+	options = dict()
+	for path, option_set in option_sets:
+		options.update(option_set)
+
+	return options
+
+def findup(path, relative_path):
+	path = os.path.abspath(path)
+	# Testing path against dirname(path) should be more reliable than testing it against '/'
+	# and work on Windows where root may be C:/ or something else.
+	while path and path != os.path.dirname(path):
+		test_path = os.path.join(path, relative_path)
+		if os.path.isfile(test_path):
+			return test_path
+
+		path = os.path.dirname(path)
+
+	return False


### PR DESCRIPTION
This is based on my other pull request so some of those commits will show up till master is merged.

The first bit of handling added stops ; from being added when the line already ends in `,` or `;`.
This, got annoying:
```js
var foo = require('foo'),
    bar = require('bar');;
```

The second bit starts adding support for jscs options and one preference.

I personally don't like the style, but I added support for the style.
Users who don't use semicolons in their code can set the `"semicolon_free"` option to `true`.
A project can set the jscs `disallowSemicolons` option and NodeRequirer will omit semicolon output.

A project's jscs `validateQuoteMarks` setting will override the user's `quotes` preference.

And,
A project's jscs `disallowSpaceBeforeBinaryOperators` and `disallowSpaceAfterBinaryOperators` options disallowing spaces around `=` will cause them to be trimmed.