### PR TITLE
Implement support for special aliases

### DIFF
--- a/NodeRequirer.py
+++ b/NodeRequirer.py
@@ -392,11 +392,11 @@ def get_module_info(module_path, view):
     In the case that the module is a node core module, the module_path and
     module_name are the same."""
 
-    aliases = utils.get_pref('alias')
+    aliased_to = utils.aliased(module_path)
     omit_extensions = utils.get_pref('omit_extensions')
 
-    if module_path in aliases:
-        module_name = aliases[module_path]
+    if aliased_to:
+        module_name = aliased_to
     else:
         module_name = os.path.basename(module_path)
         module_name, extension = os.path.splitext(module_name)

--- a/NodeRequirer.sublime-settings
+++ b/NodeRequirer.sublime-settings
@@ -37,7 +37,13 @@
         "qunit": "QUnit",
         "zepto": "$",
         "graceful-fs": "fs",
-        "findup-sync": "findup"
+        "findup-sync": "findup",
+        "gulp-util": "gutil"
+    },
+
+    // Common "alias" patterns that can be expressed using regular expressions
+    "alias-pattern": {
+        "gulp-(.+)": "\\1"
     },
 
     // Use 'single' or "double" quotes

--- a/NodeRequirer.sublime-settings
+++ b/NodeRequirer.sublime-settings
@@ -38,7 +38,8 @@
         "zepto": "$",
         "graceful-fs": "fs",
         "findup-sync": "findup",
-        "gulp-util": "gutil"
+        "gulp-util": "gutil",
+        "package.json": "pkg"
     },
 
     // Common "alias" patterns that can be expressed using regular expressions

--- a/src/utils.py
+++ b/src/utils.py
@@ -30,13 +30,20 @@ def aliased(module_path):
     aliases = get_pref('alias')
     alias_patterns = get_pref('alias-pattern')
 
+    # Resolve explicit aliases
     if module_path in aliases:
         return aliases[module_path]
 
+    # Resolve regular expression aliases
     for alias_pattern, result_pattern in alias_patterns.items():
         m = re.match(alias_pattern, module_path)
         if m:
             return m.expand(result_pattern)
+
+    # Allow the alias for package.json in any location to be defined by a "package.json" alias
+    if os.path.basename(module_path) == 'package.json':
+        if 'package.json' in aliases:
+            return aliases['package.json']
 
     return None
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -26,6 +26,20 @@ def is_local_file(module):
     return '/' in module
 
 
+def aliased(module_path):
+    aliases = get_pref('alias')
+    alias_patterns = get_pref('alias-pattern')
+
+    if module_path in aliases:
+        return aliases[module_path]
+
+    for alias_pattern, result_pattern in alias_patterns.items():
+        m = re.match(alias_pattern, module_path)
+        if m:
+            return m.expand(result_pattern)
+
+    return None
+
 def strip_snippet_groups(snippet_text):
     """
     This (admittedly complex looking) function goes through a snippet string and strips


### PR DESCRIPTION
Added support for some special types of aliases:

* The `gulp-*` to `*` pattern where `gulp-foo` is almost always used as `foo`.
  * Implemented with a regular expression "alias-pattern" that can be applied to other similar patterns.
* The pattern where `package.json` in any directory gets aliased as `pkg`.
  * This one is hardcoded to allow the `"package.json"` "alias" key to set the alias for a package.json file.
  * This fixes #36.