### PR TITLE
Add `tape` to the default aliases

### DIFF
--- a/NodeRequirer.sublime-settings
+++ b/NodeRequirer.sublime-settings
@@ -51,7 +51,8 @@
         "connect-mysql": "MySQLStore",
         "connect-sdb": "SdbStore",
         "connect-sqlite3": "SQLiteStore",
-        "package.json": "pkg"
+        "package.json": "pkg",
+        "tape": "test"
     },
 
     // Common "alias" patterns that can be expressed using regular expressions


### PR DESCRIPTION
Tape is a pretty common testing framework, and it is nearly always linked to `test`