### PR TITLE
Add aliases for rethinkdb

### DIFF
--- a/NodeRequirer.sublime-settings
+++ b/NodeRequirer.sublime-settings
@@ -52,7 +52,9 @@
         "connect-sdb": "SdbStore",
         "connect-sqlite3": "SQLiteStore",
         "package.json": "pkg",
-        "tape": "test"
+        "tape": "test",
+        "r": "rethinkdb",
+        "r": "rethinkdbdash"
     },
 
     // Common "alias" patterns that can be expressed using regular expressions


### PR DESCRIPTION
It's okay to link them both to `r` because you'd never use both drivers at the same time. Linking to `r` is how all the rethinkdb docs work, so this seems like a good default.