### PR TITLE
Ignore non-import lines before import lines

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -18,6 +18,57 @@
           "args": {
             "file": "${packages}/User/NodeRequirer.sublime-settings"
           }
+        },
+        {
+          "caption": "-"
+        },
+        {
+          "caption": "Key Bindings – Default",
+          "command": "open_file", "args":
+          {
+            "file": "${packages}/NodeRequirer/Default (OSX).sublime-keymap",
+            "platform": "OSX"
+          }
+        },
+        {
+          "caption": "Key Bindings – User",
+          "command": "open_file", "args":
+          {
+            "file": "${packages}/User/Default (OSX).sublime-keymap",
+            "platform": "OSX"
+          }
+        },
+        {
+          "caption": "Key Bindings – Default",
+          "command": "open_file", "args":
+          {
+            "file": "${packages}/NodeRequirer/Default (Linux).sublime-keymap",
+            "platform": "Linux"
+          }
+        },
+        {
+          "caption": "Key Bindings – User",
+          "command": "open_file", "args":
+          {
+            "file": "${packages}/User/Default (Linux).sublime-keymap",
+            "platform": "Linux"
+          }
+        },
+        {
+          "caption": "Key Bindings – Default",
+          "command": "open_file", "args":
+          {
+            "file": "${packages}/NodeRequirer/Default (Windows).sublime-keymap",
+            "platform": "Windows"
+          }
+        },
+        {
+          "caption": "Key Bindings – User",
+          "command": "open_file", "args":
+          {
+            "file": "${packages}/User/Default (Windows).sublime-keymap",
+            "platform": "Windows"
+          }
         }
       ]
     }]


### PR DESCRIPTION
Insert import line after existing imports, ignoring comments, 'use strict' etc. before imports.

Also, add Key Bindings config files to menu.