### PR TITLE
import undefined variables

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -18,6 +18,57 @@
           "args": {
             "file": "${packages}/User/NodeRequirer.sublime-settings"
           }
+        },
+        {
+          "caption": "-"
+        },
+        {
+          "caption": "Key Bindings – Default",
+          "command": "open_file", "args":
+          {
+            "file": "${packages}/NodeRequirer/Default (OSX).sublime-keymap",
+            "platform": "OSX"
+          }
+        },
+        {
+          "caption": "Key Bindings – User",
+          "command": "open_file", "args":
+          {
+            "file": "${packages}/User/Default (OSX).sublime-keymap",
+            "platform": "OSX"
+          }
+        },
+        {
+          "caption": "Key Bindings – Default",
+          "command": "open_file", "args":
+          {
+            "file": "${packages}/NodeRequirer/Default (Linux).sublime-keymap",
+            "platform": "Linux"
+          }
+        },
+        {
+          "caption": "Key Bindings – User",
+          "command": "open_file", "args":
+          {
+            "file": "${packages}/User/Default (Linux).sublime-keymap",
+            "platform": "Linux"
+          }
+        },
+        {
+          "caption": "Key Bindings – Default",
+          "command": "open_file", "args":
+          {
+            "file": "${packages}/NodeRequirer/Default (Windows).sublime-keymap",
+            "platform": "Windows"
+          }
+        },
+        {
+          "caption": "Key Bindings – User",
+          "command": "open_file", "args":
+          {
+            "file": "${packages}/User/Default (Windows).sublime-keymap",
+            "platform": "Windows"
+          }
         }
       ]
     }]

--- a/NodeRequirer.py
+++ b/NodeRequirer.py
@@ -54,10 +54,12 @@ class RequireFromWordCommand(sublime_plugin.TextCommand):
         if not os.path.exists(eslint_path):
             return []
 
-        args = [self.view.file_name(), '-f', 'compact']
+        args = ['-f', 'compact', '--stdin',
+                '--stdin-filename', self.view.file_name()]
 
         try:
-            output = node_bridge('', eslint_path, args)
+            text = self.view.substr(sublime.Region(0, self.view.size()))
+            output = node_bridge(text, eslint_path, args)
         except Exception as e:
             return []
 

--- a/NodeRequirer.sublime-settings
+++ b/NodeRequirer.sublime-settings
@@ -118,4 +118,8 @@
 
     // Allow for tab completion through require statement
     "snippets": true,
+
+    // find and import undefined vars with ESLint
+    // when "Require From Word" called without selected word
+    "import_undefined_vars": false
 }

--- a/src/node_bridge.py
+++ b/src/node_bridge.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2015 Andres Suarez, MIT
+# Source: https://github.com/babel/babel-sublime/blob/master/node_bridge.py
+
+import os
+import platform
+import subprocess
+
+IS_OSX = platform.system() == 'Darwin'
+IS_WINDOWS = platform.system() == 'Windows'
+
+def node_bridge(data, bin, args=[]):
+    env = None
+    startupinfo = None
+    if IS_OSX:
+        # GUI apps in OS X doesn't contain .bashrc/.zshrc set paths
+        env = os.environ.copy()
+        env['PATH'] += ':/usr/local/bin'
+    if IS_WINDOWS:
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+    try:
+        p = subprocess.Popen(['node', bin] + args,
+            stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE,
+            env=env, startupinfo=startupinfo)
+    except OSError:
+        raise Exception('Couldn\'t find Node.js. Make sure it\'s in your $PATH by running `node -v` in your command-line.')
+    stdout, stderr = p.communicate(input=data.encode('utf-8'))
+    stdout = stdout.decode('utf-8')
+    stderr = stderr.decode('utf-8')
+    if stderr:
+        raise Exception('Error: %s' % stderr)
+    else:
+        return stdout

--- a/src/utils.py
+++ b/src/utils.py
@@ -235,8 +235,12 @@ def fuzzy_match(first, second):
 
 def best_fuzzy_match(s_list, string):
     best_string = s_list.pop()
+    if string in best_string:
+        return best_string
     best_ratio = fuzzy_match(best_string, string)
     for item in s_list:
+        if string in item:
+            return item
         ratio = fuzzy_match(item, string)
         if ratio > best_ratio:
             best_ratio = ratio


### PR DESCRIPTION
(requires ESLint installed locally)

If no selection were made, `import_undefined_vars` setting is true and ESLint is available, `Require From Word` tries to find all undefined variables in source code (ESLint `no-undef` rule) and import them.