### PR TITLE
sequelize is usually PascalCased on import.

### DIFF
--- a/NodeRequirer.sublime-settings
+++ b/NodeRequirer.sublime-settings
@@ -53,6 +53,7 @@
         "connect-sqlite3": "SQLiteStore",
         "package.json": "pkg",
         "tape": "test",
+        "sequelize": "Sequelize",
         "r": "rethinkdb",
         "r": "rethinkdbdash"
     },


### PR DESCRIPTION
Almost all examples of sequelize show this pattern since Sequelize is treated as a class on import.