### PR TITLE
Alias pattern for individual lodash modules

### DIFF
--- a/NodeRequirer.sublime-settings
+++ b/NodeRequirer.sublime-settings
@@ -59,7 +59,8 @@
 
     // Common "alias" patterns that can be expressed using regular expressions
     "alias-pattern": {
-        "gulp-(.+)": "\\1"
+        "gulp-(.+)": "\\1",
+        "lodash\\.(.+)": "\\1"
     },
 
     // Use 'single' or "double" quotes


### PR DESCRIPTION
Lodash has published individual modules to npm some time ago, so you can now `npm install lodash.pick` etc.

This PR adds support for these modules to that requiring `lodash.pick` ends up with the variable name `pick` instead of `lodash`.
