### PR TITLE
Fix for non-existing dependencies

### DIFF
--- a/src/ModuleLoader.py
+++ b/src/ModuleLoader.py
@@ -158,7 +158,7 @@ class ModuleLoader():
         for dependency in dependencies:
             module_path = os.path.join(modules_path, dependency)
             if not os.path.exists(module_path):
-                return []
+                continue
 
             walk = os.walk(module_path)
             for root, dirs, files in walk:


### PR DESCRIPTION
do not break walking through dependencies if dependency is not exist in node_modules