### PR TITLE
ES6 exports, multi-dot file extensions and dirnames as index.js

### DIFF
--- a/NodeRequirer.py
+++ b/NodeRequirer.py
@@ -342,7 +342,12 @@ def get_module_info(module_path, view):
 
         # When requiring an index.js file, rename the
         # var as the directory directly above
-        if module_name == 'index' and extension.endswith(".js"):
+        consume_identical = utils.get_project_pref('dirname_as_index', view=view)
+        parent_dir = os.path.split(os.path.dirname(module_path))[-1]
+        is_module_index = module_name == 'index' and extension.endswith(".js") \
+            or consume_identical and module_name == parent_dir
+
+        if is_module_index:
             module_path = os.path.dirname(module_path)
             module_name = os.path.split(module_path)[-1]
             if module_name == '':

--- a/NodeRequirer.py
+++ b/NodeRequirer.py
@@ -338,11 +338,11 @@ def get_module_info(module_path, view):
         module_name = aliased_to
     else:
         module_name = os.path.basename(module_path)
-        module_name, extension = os.path.splitext(module_name)
+        module_name, extension = utils.splitext(module_name)
 
         # When requiring an index.js file, rename the
         # var as the directory directly above
-        if module_name == 'index' and extension == ".js":
+        if module_name == 'index' and extension.endswith(".js"):
             module_path = os.path.dirname(module_path)
             module_name = os.path.split(module_path)[-1]
             if module_name == '':
@@ -351,7 +351,7 @@ def get_module_info(module_path, view):
                 module_name = os.path.split(directory)[-1]
         # Depending on preferences, remove the file extension
         elif omit_extensions and module_path.endswith(tuple(omit_extensions)):
-            module_path = os.path.splitext(module_path)[0]
+            module_path = utils.splitext(module_path)[0]
 
         # Capitalize modules named with dashes
         # i.e. some-thing => SomeThing

--- a/NodeRequirer.sublime-settings
+++ b/NodeRequirer.sublime-settings
@@ -132,5 +132,10 @@
 
     // find and import undefined vars with ESLint
     // when "Require From Word" called without selected word
-    "import_undefined_vars": false
+    "import_undefined_vars": false,
+
+    // for use with https://github.com/toptal/component-resolver-webpack
+    // (allows `<foldername>.js` to be used in place of `index.js`)
+    // instead of `moduleName/moduleName.js` import just `moduleName`
+    "dirname_as_index": false
 }

--- a/src/ModuleLoader.py
+++ b/src/ModuleLoader.py
@@ -7,7 +7,8 @@ import json
 from NodeRequirer.src import utils
 
 HAS_REL_PATH_RE = re.compile(r"\.?\.?\/")
-IS_EXPORT_LINE = re.compile(r"exports\.(.*?)=")
+IS_EXPORT_LINE_COMMONJS = re.compile(r"exports\.(.*?)=")
+IS_EXPORT_LINE_ES6 = re.compile(r"export\s+(var|let|const|function|class)?([^()\[\]{},/*<>%\s-]+)")
 
 
 class ModuleLoader():
@@ -210,13 +211,13 @@ class ModuleLoader():
             fpath = os.path.join(fpath, 'index.js')
         f = open(fpath, 'r')
         for line in f:
-            result = re.search(IS_EXPORT_LINE, line)
+            result = re.search(IS_EXPORT_LINE_COMMONJS, line)
             if result:
                 exports.append(result.group(1).strip())
+            result = re.search(IS_EXPORT_LINE_ES6, line)
+            if result:
+                exports.append(result.group(2).strip())
 
         if len(exports) <= 1:
-            return sublime.error_message(
-                'Unable to find specific exports. Note: We currently'
-                ' only support parsing commonjs style exporting'
-            )
+            return sublime.error_message('Unable to find specific exports.')
         return exports

--- a/src/utils.py
+++ b/src/utils.py
@@ -247,3 +247,11 @@ def best_fuzzy_match(s_list, string):
             best_string = item
 
     return best_string
+
+def splitext(path):
+    """
+    Works like os.path.splitext but accounts for file names that may contain multiple dots.
+    """
+    path_without_extensions = os.path.join(os.path.dirname(path), os.path.basename(path).split(os.extsep)[0])
+    extensions = os.path.basename(path).split(os.extsep)[1:]
+    return (path_without_extensions, extensions)


### PR DESCRIPTION
Sry for the composite PR. Great plugin but I really needed all of these features to be able to use it. I guess I can split it if necessary.

This PR adds support for:

**ES6-style exports**
It doesn't support every possible export syntax (namely `export {foo as bar, bar as foo}` is a toughie and it's likely to be a multi-line export which would require a bit of refactoring) but it should cover the most common cases like `export myVar`, `export default myVar`, `export class Foo`.

**Multi-dot file extensions**
For whatever reason I have filenames like `someUtil.es6.js` (in addition to `.coffee`, `.jsx` in the same project). Instead of generating `require './someUtil.es6'` it now produces `require './someUtil'`

**Dirnames as index.js**
I heavily leverage the convention `component-resolver-wepback` (https://github.com/toptal/component-resolver-webpack) proposes, which is to have `dirName/dirName.js` instead of `dirName/index.js`. The reason is that this way you can avoid having most of your project consist of only `index.js` files (helps some fuzzy file openers and such). This might be a rather custom feature (not per an actual spec) but as it's only exposed through a custom setting I figured someone might find it useful.