### PR TITLE
Import style detection improvements

### DIFF
--- a/.build
+++ b/.build
@@ -4,8 +4,10 @@
 	"mods_load_order":
 	[
 		"src/utils.py",
+		"src/node_bridge.py",
 		"src/modules.py",
 		"src/RequireSnippet.py",
+		"src/ModuleLoader.py",
 		"NodeRequirer.py"
 	]
 }

--- a/NodeRequirer.sublime-settings
+++ b/NodeRequirer.sublime-settings
@@ -124,9 +124,14 @@
         "pg"
     ],
 
-    // Use ES6 Import Style
-    // i.e. import module from module
-    "import": false,
+    // Use ES6 Import Style. Use true to always use es6, false for always require
+    // or 'detect' to determine it based on the file context
+    // In detect mode NodeRequirer will parse the file to determine whether require/imports are used.
+    "import": "detect",
+
+    // Whether to prefer using ES6 imports or require() when neither are used in a file.
+    // Set to true for ES6 and false for Node require.
+    "detect_prefer_imports": false,
 
     // Allow for tab completion through require statement
     "snippets": true,

--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ Example `User Plugin Preferences`
     "var": "var",
     
     // Use ES6 import format, when syntactically correct. Use detect to determine based on file buffer
-    "import": false,
+    "import": "detect",
+
+    // Whether to use ES6 import or require in detect mode when
+    // the format could not be identified (e.g. when neither were used in file)
+    "detect_prefer_import": true,
 
     "alias": {
         // <module name>: <variable name>

--- a/src/RequireSnippet.py
+++ b/src/RequireSnippet.py
@@ -4,7 +4,9 @@ from .utils import get_pref, get_project_pref, get_quotes, should_add_semicolon
 from .utils import get_jscs_options, strip_snippet_groups
 import sublime
 
-CONTAINS_IMPORT = '^\s*import\s.*\sfrom\s'
+quote_block = '("([^"]+)"|\'([^\']+)\')'
+CONTAINS_IMPORT = '^\s*import\s.*\sfrom\s+%s' % quote_block
+CONTAINS_REQUIRE = '.+?require\s*\(\s*%s\s*\)' % quote_block
 
 class RequireSnippet():
 
@@ -26,11 +28,7 @@ class RequireSnippet():
         self.context_allows_semicolon = context_allows_semicolon
 
         self.es6import = self.get_project_pref('import')
-        if self.es6import == 'detect':
-            # If the regexp is not found, find will return a tuple (-1, -1) in Sublime 3 or None in Sublime 2 
-            # https://github.com/SublimeTextIssues/Core/issues/534
-            contains_import = self.view.find(CONTAINS_IMPORT, 0)
-            self.es6import = all(x >= 0 for x in contains_import) if float(sublime.version()) >= 3000 else contains_import is not None
+        if self.es6import == 'detect': self.detect_import()
 
         self.var_type = self.get_project_pref('var')
         if self.var_type not in ('var', 'const', 'let', 'import'):
@@ -41,6 +39,23 @@ class RequireSnippet():
             self.jscs_options = get_jscs_options(self.file_name)
         self.exports = exports
         self.destructuring = destructuring or self.es6import
+
+    def detect_import(self):
+        """ Helper to determine whether to use es6 or require imports based on file context """
+        if self.contains_match(CONTAINS_IMPORT): self.es6import = True
+        elif self.contains_match(CONTAINS_REQUIRE): self.es6import = False
+        else: self.es6import = self.get_project_pref('detect_prefer_imports')
+
+
+    def contains_match(self, regexp):
+        """
+            Helper to determine whether a regexp is contained in the current file in sublime 3 or sublime 2
+        """
+        # If the regexp is not found, find will return a tuple (-1, -1) in Sublime 3 or None in Sublime 2 
+        # https://github.com/SublimeTextIssues/Core/issues/534
+        contains_import = self.view.find(regexp, 0)
+        return contains_import.size() > 0 if float(sublime.version()) >= 3000 else contains_import is not None
+
 
     def get_formatted_code(self):
         """Return formatted code for insertion."""


### PR DESCRIPTION
This finishes #91 which was a WIP when merged. Currently the way this works is when in `detect` mode it parses the current file to determine

1) is any ES6 imports used in current file? -> use es6 import
2) is any require statement used? -> use require
3) otherwise use preferred method (option, require by default)

![demo](https://cloud.githubusercontent.com/assets/3475472/15994125/71788bd0-30c9-11e6-9901-1695a072765f.gif)


/cc @ganemone 