### PR TITLE
Add querystring to list of core modules

### DIFF
--- a/src/modules.py
+++ b/src/modules.py
@@ -16,6 +16,7 @@ core_modules = [
     'os',
     'path',
     'punycode',
+    'querystring',
     'readline',
     'stream',
     'string_decoder',


### PR DESCRIPTION
[querystring](https://nodejs.org/api/querystring.html) is a core node module and has been for a while.
Figured it would be nice to have it added.